### PR TITLE
Fix memory leak when regenerating text meshes

### DIFF
--- a/static/js/3d_renderer.js
+++ b/static/js/3d_renderer.js
@@ -161,10 +161,22 @@ function renderText(textData) {
             return;
         }
         
-        // Verwijder bestaande textMesh als die er is
+        // Verwijder bestaande textMesh als die er is en maak geheugen vrij
         if (textMesh) {
             console.log('Bestaande textMesh verwijderen');
             scene.remove(textMesh);
+
+            // Ruim geometry en materialen netjes op om geheugenlekken te voorkomen
+            if (textMesh.geometry) {
+                textMesh.geometry.dispose();
+            }
+            if (Array.isArray(textMesh.material)) {
+                textMesh.material.forEach(mat => mat.dispose());
+            } else if (textMesh.material) {
+                textMesh.material.dispose();
+            }
+
+            textMesh = null;
         }
         
         // Update de achtergrondkleur van de renderer container om contrast te verbeteren


### PR DESCRIPTION
## Summary
- clean up existing meshes before adding new text geometry to the scene

## Testing
- `python -m py_compile app.py text_to_3d.py`