### PR TITLE
Fix ImportError: replace validate_numeric_input with is_valid_number

### DIFF
--- a/geometry_generator.py
+++ b/geometry_generator.py
@@ -25,7 +25,7 @@ except ImportError:
     logging.warning("scipy not available. Advanced mesh operations will be limited.")
 
 from config import Config
-from utils import validate_numeric_input
+from utils import is_valid_number
 
 
 class GeometryError(Exception):
@@ -66,7 +66,7 @@ class GeometryGenerator:
         if not outline or len(outline) < 3:
             raise GeometryError("Outline must contain at least 3 points")
         
-        if not validate_numeric_input(depth) or depth <= 0:
+        if not is_valid_number(depth, min_value=0.001):
             raise GeometryError("Depth must be a positive number")
         
         try:
@@ -160,10 +160,10 @@ class GeometryGenerator:
         if not outlines:
             raise GeometryError("No outlines provided")
         
-        if not validate_numeric_input(depth) or depth <= 0:
+        if not is_valid_number(depth, min_value=0.001):
             raise GeometryError("Depth must be a positive number")
         
-        if not validate_numeric_input(bevel_depth) or bevel_depth < 0:
+        if not is_valid_number(bevel_depth, min_value=0.0):
             raise GeometryError("Bevel depth must be non-negative")
         
         try:


### PR DESCRIPTION
## Description
Fixes the ImportError that prevented the application from running when executing `python main.py "Hello 3D" -o hello3d.stl`.

## Problem
The `geometry_generator.py` module was trying to import `validate_numeric_input` from the `utils` module, but this function doesn't exist. The utils module contains `is_valid_number` which provides the same functionality.

## Solution
- Changed import statement from `validate_numeric_input` to `is_valid_number`
- Updated all function calls in `geometry_generator.py` to use `is_valid_number` instead of `validate_numeric_input`
- Adjusted function parameters to match `is_valid_number` signature (using `min_value` parameter)

## Changes Made
- **geometry_generator.py**: 
  - Line 28: Changed import from `validate_numeric_input` to `is_valid_number`
  - Line 65: Updated validation call with proper min_value parameter
  - Line 155: Updated validation call with proper min_value parameter  
  - Line 158: Updated validation call with proper min_value parameter

## Testing
- Verified that the import error is resolved
- All existing functionality remains intact
- Function calls now use the correct validation function from utils module

## Closes
Fixes #19