### PR TITLE
Fix duplicate export_format argument bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -486,11 +486,18 @@ class Text3DGenerator:
             
             # Step 5: Export model
             if output_path:
+                # Extract export format from options
+                export_format = options.get('export_format', 'STL')
+                
+                # Filter out export_format from export_options to avoid duplicate argument
+                export_options = {k: v for k, v in options.items() 
+                                if k.startswith('export_') and k != 'export_format'}
+                
                 exported_path = self.export_model(
                     geometry_data,
                     output_path,
-                    options.get('export_format', 'STL'),
-                    **{k: v for k, v in options.items() if k.startswith('export_')}
+                    export_format,
+                    **export_options
                 )
                 results['exported_path'] = exported_path
             


### PR DESCRIPTION
## Description
Fixed critical bug where `export_format` was passed both as positional argument and in export_options dictionary, causing TypeError during model export.

## Problem
The error occurred in the `run_workflow` method when calling `export_model()`:
```
Text3DGenerator.export_model() got multiple values for argument 'export_format'
```

## Root Cause
In `run_workflow()` method, line 456-462:
- `export_format` was passed as positional argument: `options.get('export_format', 'STL')`
- `export_format` was also included in `**export_options` when filtering with `k.startswith('export_')`

## Solution
- Extract `export_format` from options separately
- Filter out `export_format` from export_options to avoid duplicate argument
- Pass `export_format` as positional argument and remaining export options as keyword arguments

## Changes Made
- Modified `run_workflow()` method in `main.py` (lines 456-467)
- Added explicit filtering to exclude `export_format` from export_options dictionary
- Maintained backward compatibility with all existing functionality

## Testing
- [x] Verified fix resolves the TypeError
- [x] Confirmed all export formats still work correctly
- [x] Validated workflow continues to function as expected
- [x] No breaking changes to existing API

## Fixes
Closes #22